### PR TITLE
Fix BluetoothWatcher connected lookup

### DIFF
--- a/src/BluetoothWatcher/BluetoothWatcher.cpp
+++ b/src/BluetoothWatcher/BluetoothWatcher.cpp
@@ -16,17 +16,18 @@ BluetoothWatcher::BluetoothWatcher(QObject *_parent) :
 
 void BluetoothWatcher::onPpsFileReady(const QVariantMap& map) {
     if (map.contains("activity_state")) {
-        bool connected = (map["activity_state"].toInt() == 16);
-        bool deviceWasAlreadyConnected = m_connectedDevices.contains(map["_ppsMapTitle"].toString());
+        const bool connected = (map["activity_state"].toInt() == 16);
+        const QString deviceName = map["_ppsMapTitle"].toString();
+        const bool deviceWasAlreadyConnected = m_connectedDevices.contains(deviceName);
 
         if (connected != deviceWasAlreadyConnected) {
             if (connected) {
-                m_connectedDevices.append(map["_ppsMapTitle"].toString().remove("@"));
-                emit bluetoothDeviceConnected(map["_ppsMapTitle"].toString());
+                m_connectedDevices.append(deviceName);
+                emit bluetoothDeviceConnected(deviceName);
             }
             else {
-                m_connectedDevices.removeAll(map["_ppsMapTitle"].toString().remove("@"));
-                emit bluetoothDeviceDisconnected(map["_ppsMapTitle"].toString());
+                m_connectedDevices.removeAll(deviceName);
+                emit bluetoothDeviceDisconnected(deviceName);
             }
             emit connectedDevicesChanged(m_connectedDevices);
         }


### PR DESCRIPTION
Your last fix reverted the actual fix and now MAC addresses without @ are written to the lookup table but with @ is searched for already connected devices.

using the variable, all instances use the same form and its fairly easy to add the `.remove("@")` once you are willing to change the interface ;)